### PR TITLE
Allow an override so we can have a CI job in emergency situations to run the kafka reconciliation at any time

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ Then the lambda will start the AWS Glue job with its required parameters.
 |MANIFEST_S3_INPUT_PARQUET_LOCATION_COUNTS | Full S3 URI to counts output location |
 |MANIFEST_S3_INPUT_PARQUET_LOCATION_MISMATCHED_TIMESTAMPS | Full S3 URI to mismatched timestamps output location |
 |MANIFEST_S3_OUTPUT_LOCATION | Output location on S3 for Athena query outputs |
+
+# Batch checks override
+
+If you want to override the batch checks (i.e. for recovery CI pipelines), then when invoking the lambda you can pass in `ignoreBatchChecks` in the `details` dict with a value of `true`.

--- a/src/glue_launcher_lambda/glue_launcher.py
+++ b/src/glue_launcher_lambda/glue_launcher.py
@@ -539,7 +539,10 @@ def handler(event, context):
     job_status = detail_dict[JOB_STATUS_KEY]
     job_queue = detail_dict[JOB_QUEUE_KEY]
 
-    override_batch_checks = BATCH_CHECKS_OVERRIDE_KEY in detail_dict and detail_dict[BATCH_CHECKS_OVERRIDE_KEY] == "true"
+    override_batch_checks = (
+        BATCH_CHECKS_OVERRIDE_KEY in detail_dict
+        and detail_dict[BATCH_CHECKS_OVERRIDE_KEY] == "true"
+    )
 
     if job_status not in FINISHED_JOB_STATUSES:
         logger.info(


### PR DESCRIPTION
Allow an override so we can have a CI job in emergency situations to run the kafka reconciliation at any time